### PR TITLE
Fix windows crush

### DIFF
--- a/scripts/tag_autocomplete_helper.py
+++ b/scripts/tag_autocomplete_helper.py
@@ -15,9 +15,10 @@ EXT_PATH = FILE_DIR.joinpath('extensions')
 
 def get_tags_base_path():
     script_path = Path(scripts.basedir())
-    if (script_path.is_relative_to(EXT_PATH)):
+    try:
+        script_path.relative_to(EXT_PATH) # should raise ValueError if not in extensions
         return script_path.joinpath('tags')
-    else:
+    except ValueError:
         return FILE_DIR.joinpath('tags')
 
 


### PR DESCRIPTION
```
stable-diffusion-webui\extensions\tag-autocomplete\scripts\tag_autocomplete_helper.py", line 18, in get_tags_base_path
    if (script_path.is_relative_to(EXT_PATH)):
AttributeError: 'WindowsPath' object has no attribute 'is_relative_to'
```
This fix solves that problem. If the code is not very nice, you can suggest something better.