### PR TITLE
Allow comments within wildcards

### DIFF
--- a/javascript/tagAutocomplete.js
+++ b/javascript/tagAutocomplete.js
@@ -437,7 +437,7 @@ async function autocomplete(textArea, prompt, fixedTag = null) {
             wcPair = wildcardExtFiles.find(x => x[1].toLowerCase() === wcFile);
 
         let wildcards = (await readFile(`file/${wcPair[0]}/${wcPair[1]}.txt`)).split("\n")
-            .filter(x => x.trim().length > 0); // Remove empty lines
+            .filter(x => x.trim().length > 0 && !x.startsWith('#'));  // Remove empty lines and comments
 
         results = wildcards.filter(x => (wcWord !== null && wcWord.length > 0) ? x.toLowerCase().includes(wcWord) : x) // Filter by tagword
             .map(x => [wcFile + ": " + x.trim(), "wildcardTag"]); // Mark as wildcard


### PR DESCRIPTION
I am using the [UnivAICharGen](https://github.com/Klokinator/UnivAICharGen) for wildcard/prompt generation together with my tweaked wildcards.

However, they added support for comments (every line starting with an "#") within wildcards. 

Without this patch, the following happens:
<img width="1024" alt="Screenshot 2022-10-30 at 16 25 10" src="https://user-images.githubusercontent.com/495625/198886890-f52b8680-f17e-442c-acdf-03024e91c55c.png">

This change will filter out every line starting with a hashtag.

<img width="1022" alt="Screenshot 2022-10-30 at 16 27 26" src="https://user-images.githubusercontent.com/495625/198887002-4ace36bd-f252-42e0-915c-b4eb8f612d07.png">


