### PR TITLE
fix bug

### DIFF
--- a/scripts/tag_autocomplete_helper.py
+++ b/scripts/tag_autocomplete_helper.py
@@ -11,7 +11,7 @@ FILE_DIR = Path().absolute()
 EXT_PATH = FILE_DIR.joinpath('extensions')
 
 # Tags base path
-TAGS_PATH = Path(scripts.basedir()).joinpath('tags')
+TAGS_PATH = FILE_DIR.joinpath('tags')
 
 # The path to the folder containing the wildcards and embeddings
 WILDCARD_PATH = FILE_DIR.joinpath('scripts/wildcards')


### PR DESCRIPTION
```
Error loading script: tag_autocomplete_helper.py
Traceback (most recent call last):
  File "E:\stable-diffusion-webui\modules\scripts.py", line 71, in load_scripts
    exec(compiled, module.__dict__)
  File "E:\stable-diffusion-webui\scripts\tag_autocomplete_helper.py", line 14, in <module>
    TAGS_PATH = Path(scripts.basedir()).joinpath('tags')
AttributeError: module 'modules.scripts' has no attribute 'basedir'
```