### PR TITLE
Improved search function

### DIFF
--- a/javascript/tagAutocomplete.js
+++ b/javascript/tagAutocomplete.js
@@ -354,7 +354,7 @@ function addResultsToList(textArea, results, tagword, resetList) {
         // If the tag matches the tagword, we don't need to display the alias
         if (result[3] && !result[0].includes(tagword)) { // Alias
             let splitAliases = result[3].split(",");
-            let bestAlias = splitAliases.find(a => a.toLowerCase().search("(^|[^a-zA-Z])" + tagword)>-1);
+            let bestAlias = splitAliases.find(a => a.toLowerCase().includes(tagword));
 
             // search in translations if no alias matches
             if (!bestAlias) {

--- a/javascript/tagAutocomplete.js
+++ b/javascript/tagAutocomplete.js
@@ -542,7 +542,15 @@ async function autocomplete(textArea, prompt, fixedTag = null) {
             tempResults = embeddings;
         }
         // Since some tags are kaomoji, we have to still get the normal results first.
-        genericResults = allTags.filter(x => x[0].toLowerCase().search("(^|[^a-zA-Z])" + tagword)>-1).slice(0, acConfig.maxResults);
+        // Create escaped search regex with support for * as a start placeholder
+        let searchRegex;
+        if (tagword.startsWith("*")) {
+            tagword = tagword.slice(1);
+            searchRegex = new RegExp(`${escapeRegExp(tagword)}`, 'i');
+        } else {
+            searchRegex = new RegExp(`(^|[^a-zA-Z])${escapeRegExp(tagword)}`, 'i');
+        }
+        genericResults = allTags.filter(x => x[0].toLowerCase().search(searchRegex) > -1).slice(0, acConfig.maxResults);
         results = genericResults.concat(tempResults.map(x => ["Embeddings: " + x.trim(), "embedding"])); // Mark as embedding
     } else {
         // Create escaped search regex with support for * as a start placeholder

--- a/javascript/tagAutocomplete.js
+++ b/javascript/tagAutocomplete.js
@@ -352,16 +352,16 @@ function addResultsToList(textArea, results, tagword, resetList) {
 
         let displayText = "";
         // If the tag matches the tagword, we don't need to display the alias
-        if (result[3] && !result[0].includes(tagword)) { // Alias
+        if (result[3] && !result[0].search("(^|[^a-zA-Z])" + tagword)>-1) { // Alias
             let splitAliases = result[3].split(",");
-            let bestAlias = splitAliases.find(a => a.toLowerCase().includes(tagword));
+            let bestAlias = splitAliases.find(a => a.toLowerCase().search("(^|[^a-zA-Z])" + tagword)>-1);
 
             // search in translations if no alias matches
             if (!bestAlias) {
                 let tagOrAlias = pair => pair[0] === result[0] || result[3].split(",").includes(pair[0]);
                 var tArray = [...translations];
                 if (tArray) {
-                    var translationKey = [...translations].find(pair => tagOrAlias(pair) && pair[1].includes(tagword));
+                    var translationKey = [...translations].find(pair => tagOrAlias(pair) && pair[1].search("(^|[^a-zA-Z])" + tagword)>-1);
                     if (translationKey)
                         bestAlias = translationKey[0];
                 }
@@ -542,18 +542,18 @@ async function autocomplete(textArea, prompt, fixedTag = null) {
             tempResults = embeddings;
         }
         // Since some tags are kaomoji, we have to still get the normal results first.
-        genericResults = allTags.filter(x => x[0].toLowerCase().includes(tagword)).slice(0, acConfig.maxResults);
+        genericResults = allTags.filter(x => x[0].toLowerCase().search("(^|[^a-zA-Z])" + tagword)>-1).slice(0, acConfig.maxResults);
         results = genericResults.concat(tempResults.map(x => ["Embeddings: " + x.trim(), "embedding"])); // Mark as embedding
     } else {
         // If onlyShowAlias is enabled, we don't need to include normal results
         if (acConfig.alias.onlyShowAlias) {
-            results = allTags.filter(x => x[3] && x[3].toLowerCase().includes(tagword));
+            results = allTags.filter(x => x[3] && x[3].toLowerCase().search("(^|[^a-zA-Z])" + tagword)>-1);
         } else {
             // Else both normal tags and aliases/translations are included depending on the config
-            let baseFilter = (x) => x[0].toLowerCase().includes(tagword);
-            let aliasFilter = (x) => x[3] && x[3].toLowerCase().includes(tagword);
-            let translationFilter = (x) => (translations.has(x[0]) && translations.get(x[0]).toLowerCase().includes(tagword))
-                || x[3] && x[3].split(",").some(y => translations.has(y) && translations.get(y).toLowerCase().includes(tagword));
+            let baseFilter = (x) => x[0].toLowerCase().search("(^|[^a-zA-Z])" + tagword)>-1;
+            let aliasFilter = (x) => x[3] && x[3].toLowerCase().search("(^|[^a-zA-Z])" + tagword)>-1;
+            let translationFilter = (x) => (translations.has(x[0]) && translations.get(x[0]).toLowerCase().search("(^|[^a-zA-Z])" + tagword)>-1)
+                || x[3] && x[3].split(",").some(y => translations.has(y) && translations.get(y).toLowerCase().search("(^|[^a-zA-Z])" + tagword)>-1);
             
             let fil;
             if (acConfig.alias.searchByAlias && acConfig.translation.searchByTranslation)

--- a/javascript/tagAutocomplete.js
+++ b/javascript/tagAutocomplete.js
@@ -547,7 +547,7 @@ async function autocomplete(textArea, prompt, fixedTag = null) {
     } else {
         // If onlyShowAlias is enabled, we don't need to include normal results
         if (acConfig.alias.onlyShowAlias) {
-            results = allTags.filter(x => x[3] && x[3].toLowerCase().search("(^|[^a-zA-Z])" + tagword)>-1);
+            results = allTags.filter(x => x[3] && x[3].toLowerCase().search(searchRegex) >- 1);
         } else {
             // Else both normal tags and aliases/translations are included depending on the config
             let baseFilter = (x) => x[0].toLowerCase().search("(^|[^a-zA-Z])" + tagword)>-1;

--- a/javascript/tagAutocomplete.js
+++ b/javascript/tagAutocomplete.js
@@ -550,10 +550,10 @@ async function autocomplete(textArea, prompt, fixedTag = null) {
             results = allTags.filter(x => x[3] && x[3].toLowerCase().search(searchRegex) >- 1);
         } else {
             // Else both normal tags and aliases/translations are included depending on the config
-            let baseFilter = (x) => x[0].toLowerCase().search("(^|[^a-zA-Z])" + tagword)>-1;
-            let aliasFilter = (x) => x[3] && x[3].toLowerCase().search("(^|[^a-zA-Z])" + tagword)>-1;
-            let translationFilter = (x) => (translations.has(x[0]) && translations.get(x[0]).toLowerCase().search("(^|[^a-zA-Z])" + tagword)>-1)
-                || x[3] && x[3].split(",").some(y => translations.has(y) && translations.get(y).toLowerCase().search("(^|[^a-zA-Z])" + tagword)>-1);
+            let baseFilter = (x) => x[0].toLowerCase().search(searchRegex) >- 1;
+            let aliasFilter = (x) => x[3] && x[3].toLowerCase().search(searchRegex) >- 1;
+            let translationFilter = (x) => (translations.has(x[0]) && translations.get(x[0]).toLowerCase().search(searchRegex) >- 1)
+                || x[3] && x[3].split(",").some(y => translations.has(y) && translations.get(y).toLowerCase().search(searchRegex) >- 1);
             
             let fil;
             if (acConfig.alias.searchByAlias && acConfig.translation.searchByTranslation)

--- a/javascript/tagAutocomplete.js
+++ b/javascript/tagAutocomplete.js
@@ -352,7 +352,7 @@ function addResultsToList(textArea, results, tagword, resetList) {
 
         let displayText = "";
         // If the tag matches the tagword, we don't need to display the alias
-        if (result[3] && !result[0].search("(^|[^a-zA-Z])" + tagword)>-1) { // Alias
+        if (result[3] && !result[0].includes(tagword)) { // Alias
             let splitAliases = result[3].split(",");
             let bestAlias = splitAliases.find(a => a.toLowerCase().search("(^|[^a-zA-Z])" + tagword)>-1);
 

--- a/javascript/tagAutocomplete.js
+++ b/javascript/tagAutocomplete.js
@@ -545,6 +545,14 @@ async function autocomplete(textArea, prompt, fixedTag = null) {
         genericResults = allTags.filter(x => x[0].toLowerCase().search("(^|[^a-zA-Z])" + tagword)>-1).slice(0, acConfig.maxResults);
         results = genericResults.concat(tempResults.map(x => ["Embeddings: " + x.trim(), "embedding"])); // Mark as embedding
     } else {
+        // Create escaped search regex with support for * as a start placeholder
+        let searchRegex;
+        if (tagword.startsWith("*")) {
+            tagword = tagword.slice(1);
+            searchRegex = new RegExp(`${escapeRegExp(tagword)}`, 'i');
+        } else {
+            searchRegex = new RegExp(`(^|[^a-zA-Z])${escapeRegExp(tagword)}`, 'i');
+        }    
         // If onlyShowAlias is enabled, we don't need to include normal results
         if (acConfig.alias.onlyShowAlias) {
             results = allTags.filter(x => x[3] && x[3].toLowerCase().search(searchRegex) >- 1);

--- a/javascript/tagAutocomplete.js
+++ b/javascript/tagAutocomplete.js
@@ -361,7 +361,7 @@ function addResultsToList(textArea, results, tagword, resetList) {
                 let tagOrAlias = pair => pair[0] === result[0] || result[3].split(",").includes(pair[0]);
                 var tArray = [...translations];
                 if (tArray) {
-                    var translationKey = [...translations].find(pair => tagOrAlias(pair) && pair[1].search("(^|[^a-zA-Z])" + tagword)>-1);
+                    var translationKey = [...translations].find(pair => tagOrAlias(pair) && pair[1].includes(tagword));
                     if (translationKey)
                         bestAlias = translationKey[0];
                 }


### PR DESCRIPTION
English only matches the beginning of words
![image](https://user-images.githubusercontent.com/60730393/201648140-db0da428-c1e8-40a9-9c05-32f64ea38313.png)



Does not affect Chinese search
![image](https://user-images.githubusercontent.com/60730393/201578317-95ecc75d-153f-4058-b42c-558a309dc5a6.png)



If you want to use the previous search, just add a *
![image](https://user-images.githubusercontent.com/60730393/201579428-6c332dd5-7cf5-40ea-80b8-0231517833be.png)
