### PR TITLE
Support for UnivAICharGen .yaml wildcards

### DIFF
--- a/javascript/tagAutocomplete.js
+++ b/javascript/tagAutocomplete.js
@@ -680,10 +680,9 @@ async function autocomplete(textArea, prompt, fixedTag = null) {
             umiPreviousTags = umiTags;
 
             // Show all condition
-            let currentSubPrompt = umiSubPrompts.find(x => x[0].includes(tagword[0]))[0];
-            let showAll = currentSubPrompt.endsWith("[") || currentSubPrompt.endsWith("[--") || currentSubPrompt.endsWith("|");
+            let showAll = tagword.endsWith("[") || tagword.endsWith("[--") || tagword.endsWith("|");
 
-            console.log(currentSubPrompt, umiTags, diff, tagCountChange)
+            console.log(tagword, umiTags, diff, tagCountChange)
 
             // Exit early if the user closed the bracket manually
             if ((!diff || diff.length === 0 || (diff.length === 1 && tagCountChange < 0)) && !showAll) {

--- a/scripts/tag_autocomplete_helper.py
+++ b/scripts/tag_autocomplete_helper.py
@@ -73,8 +73,10 @@ def get_ext_wildcard_tags():
                             wildcard_tags[tag] += 1
         except yaml.YAMLError as exc:
             print(exc)
+    # Sort by count
+    sorted_tags = sorted(wildcard_tags.items(), key=lambda item: item[1], reverse=True)
     output = []
-    for tag, count in wildcard_tags.items():
+    for tag, count in sorted_tags:
         output.append(f"{tag},{count}")
     return output
 
@@ -136,12 +138,10 @@ if WILDCARD_EXT_PATHS is not None:
     wildcards_ext = get_ext_wildcards()
     if wildcards_ext:
         write_to_temp_file('wce.txt', wildcards_ext)
-
-# Write extension wildcards to wce.txt if found
-if WILDCARD_EXT_PATHS is not None:
-    wildcards_ext = get_ext_wildcard_tags()
-    if wildcards_ext:
-        write_to_temp_file('wcet.txt', wildcards_ext)
+    # Write yaml extension wildcards to wcet.txt if found
+    wildcards_yaml_ext = get_ext_wildcard_tags()
+    if wildcards_yaml_ext:
+        write_to_temp_file('wcet.txt', wildcards_yaml_ext)
 
 # Write embeddings to emb.txt if found
 if EMB_PATH.exists():


### PR DESCRIPTION
[UMI v0.3](https://github.com/Klokinator/UnivAICharGen) introduced a new .yaml-based recursive wildcard system where wildcards can be selected based on internal tags. This adds basic support for that system, showing relevant wildcard tags when typing `<[`, including support for chaining various tags inside the UMI tag definition, like `<[TagA][TagB]>`.

Closes #84.