### PR TITLE
Allow for selecting an empty tagFile to disable booru suggestions

### DIFF
--- a/javascript/tagAutocomplete.js
+++ b/javascript/tagAutocomplete.js
@@ -132,7 +132,7 @@ var translations = new Map();
 
 async function loadTags(c) {
     // Load main tags and aliases
-    if (allTags.length === 0) {
+    if (allTags.length === 0 && c.tagFile && c.tagFile !== "None") {
         try {
             allTags = await loadCSV(`${tagBasePath}/${c.tagFile}?${new Date().getTime()}`);
         } catch (e) {

--- a/scripts/tag_autocomplete_helper.py
+++ b/scripts/tag_autocomplete_helper.py
@@ -153,7 +153,7 @@ if EMB_PATH.exists():
 def on_ui_settings():
     TAC_SECTION = ("tac", "Tag Autocomplete")
     # Main tag file
-    shared.opts.add_option("tac_tagFile", shared.OptionInfo("danbooru.csv", "Tag filename", gr.Dropdown, lambda: {"choices": csv_files}, refresh=update_tag_files, section=TAC_SECTION))
+    shared.opts.add_option("tac_tagFile", shared.OptionInfo("danbooru.csv", "Tag filename", gr.Dropdown, lambda: {"choices": csv_files_withnone}, refresh=update_tag_files, section=TAC_SECTION))
     # Active in settings
     shared.opts.add_option("tac_active", shared.OptionInfo(True, "Enable Tag Autocompletion", section=TAC_SECTION))
     shared.opts.add_option("tac_activeIn.txt2img", shared.OptionInfo(True, "Active in txt2img (Requires restart)", section=TAC_SECTION))


### PR DESCRIPTION
Hi there, @Klokinator wanted to be able to disable regular booru tag suggestions when using yaml autocomplete. This PR implements it.