### PR TITLE
Umi suggestion filtering

### DIFF
--- a/scripts/tag_autocomplete_helper.py
+++ b/scripts/tag_autocomplete_helper.py
@@ -61,16 +61,14 @@ def get_ext_wildcard_tags():
     for path in WILDCARD_EXT_PATHS:
         yaml_files.extend(p for p in path.rglob("*.yml"))
         yaml_files.extend(p for p in path.rglob("*.yaml"))
+    count = 0
     for path in yaml_files:
         try:
             with open(path, encoding="utf8") as file:
                 data = yaml.safe_load(file)
                 for item in data:
-                    for _, tag in enumerate(data[item]['Tags']):
-                        if tag not in wildcard_tags:
-                            wildcard_tags[tag] = 1
-                        else:
-                            wildcard_tags[tag] += 1
+                    wildcard_tags[count] = ','.join(data[item]['Tags'])
+                    count += 1
         except yaml.YAMLError as exc:
             print(exc)
     # Sort by count


### PR DESCRIPTION
This is implementing an initial version of tag filtering. The goal is to get suggestions that take previous tags into account. This will make Umi prompting viable for widespread use. Right now debugging prompts it a bit tedious because we have to run the prompt to get debug info about what keywords get matched.

I still have to find a good solution for optional tags, so that it will match all other tags no matter where they are defined and only limit the selection to what's filtered through neg and pos parts.

https://user-images.githubusercontent.com/116893749/209415626-0444e51d-27b4-4fac-9928-c82dbb9d4f02.mov

Code quality and naming feedback appreciated. Wrote it late at night and I'm surprised it even works.