### PR TITLE
Fixes repeated file loads during setup and limits result width

### DIFF
--- a/javascript/tagAutocomplete.js
+++ b/javascript/tagAutocomplete.js
@@ -61,8 +61,9 @@ const autocompleteCSS = `
         display: flex;
     }
     .acListItem {
-        overflow: hidden;
-        white-space: nowrap;
+        /*overflow: hidden;
+        white-space: nowrap;*/
+        white-space: break-spaces;
     }
     .acMetaText {
         position: relative;

--- a/javascript/tagAutocomplete.js
+++ b/javascript/tagAutocomplete.js
@@ -986,7 +986,6 @@ function navigateInList(textArea, event) {
 
 // One-time setup, triggered from onUiUpdate
 async function setup() {
-  console.log('One-time setup, triggered from onUiUpdate')
     // Load colors
     CFG["colors"] = (await readFile(`${tagBasePath}/colors.json?${new Date().getTime()}`, true));
 

--- a/javascript/tagAutocomplete.js
+++ b/javascript/tagAutocomplete.js
@@ -986,6 +986,7 @@ function navigateInList(textArea, event) {
 
 // One-time setup, triggered from onUiUpdate
 async function setup() {
+  console.log('One-time setup, triggered from onUiUpdate')
     // Load colors
     CFG["colors"] = (await readFile(`${tagBasePath}/colors.json?${new Date().getTime()}`, true));
 
@@ -1147,15 +1148,17 @@ async function setup() {
     }
     gradioApp().appendChild(acStyle);
 }
-
+let loading = false;
 onUiUpdate(async () => {
+    if (loading) return;
     if (Object.keys(opts).length === 0) return;
     if (CFG) return;
-
+    loading = true;
     // Get our tag base path from the temp file
     tagBasePath = await readFile(`tmp/tagAutocompletePath.txt?${new Date().getTime()}`);
     // Load config from webui opts
     await syncOptions();
     // Rest of setup
     setup();
+    loading = false;
 });

--- a/javascript/tagAutocomplete.js
+++ b/javascript/tagAutocomplete.js
@@ -35,6 +35,7 @@ const autocompleteCSS = `
     .autocompleteResults {
         position: absolute;
         z-index: 999;
+        max-width: calc(100% - 1.5em);
         margin: 5px 0 0 0;
         background-color: var(--results-bg) !important;
         border: var(--results-border-width) solid var(--results-border-color) !important;


### PR DESCRIPTION
有两个改动
1. tagAutocomplete文件在初始化时会持续的下载txt文件直到opts有值才能停止，在网络不好的情况下会导致初次加载很慢。
2. 限制显示tag的浮窗的宽度。手机端有时会出现tag太长，显示浮窗超出屏幕范围的情况，这个修改会让这种情况的tag自动换行。

我不知道这样提交pull request是否合理，如果有问题，请不用合并。