### PR TITLE
Fix : missing colors.json file 报错找不到colors.json

### DIFF
--- a/tags/colors.json
+++ b/tags/colors.json
@@ -1,0 +1,21 @@
+{
+	"danbooru": {
+		"-1": ["red", "maroon"],
+		"0": ["lightblue", "dodgerblue"],
+		"1": ["indianred", "firebrick"],
+		"3": ["violet", "darkorchid"],
+		"4": ["lightgreen", "darkgreen"],
+		"5": ["orange", "darkorange"]
+	},
+	"e621": {
+		"-1": ["red", "maroon"],
+		"0": ["lightblue", "dodgerblue"],
+		"1": ["gold", "goldenrod"],
+		"3": ["violet", "darkorchid"],
+		"4": ["lightgreen", "darkgreen"],
+		"5": ["tomato", "darksalmon"],
+		"6": ["red", "maroon"],
+		"7": ["whitesmoke", "black"],
+		"8": ["seagreen", "darkseagreen"]
+	}
+}


### PR DESCRIPTION
Fix the issue where loading of the extension fails in very rare cases due to a missing colors.json file in the tag folder. After cloning the repository to your extension folder, the web UI console throws an error indicating that the file is missing. If possible, please provide a PR template.
解决极个别情况下，提示报错找不到标签文件夹中colors.json文件，导致扩展加载失败问题。
克隆到你的扩展文件夹之后，webui运行控制台报错找不到文件
方便的话，请提供一个PR模板