### PR TITLE
fixed issue in which dark mode was not detected on gradio 3.28.1

### DIFF
--- a/javascript/tagAutocomplete.js
+++ b/javascript/tagAutocomplete.js
@@ -895,7 +895,8 @@ async function setup() {
     // Add style to dom
     let acStyle = document.createElement('style');
     //let css = gradioApp().querySelector('.dark') ? autocompleteCSS_dark : autocompleteCSS_light;
-    let mode = gradioApp().querySelector('.dark') ? 0 : 1;
+    //let mode = gradioApp().querySelector(".dark") ? 0 : 1;
+    let mode = document.querySelector(".dark") ? 0 : 1;
     // Check if we are on webkit
     let browser = navigator.userAgent.toLowerCase().indexOf('firefox') > -1 ? "firefox" : "other";
     


### PR DESCRIPTION
with the gradio update to 3.28.1 the dark class got taken off of the gradioApp object and is instead on the body object. I changed the code to instead do a querySelector check on the entire document as to future proof any other possible location changes.

I tested this version on commit [72cd27a13587c9579942577e9e3880778be195f6](https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/72cd27a13587c9579942577e9e3880778be195f6) of automatic, 
commit [6fbe525f7dafd63b447334b6c476c190b02da7cb](https://github.com/anapnoe/stable-diffusion-webui-ux/commit/6fbe525f7dafd63b447334b6c476c190b02da7cb) of webui-ux, and 
commit [d4a748d758e1f3dd4bdf36c045fc30113043fe50](https://github.com/vladmandic/automatic/commit/d4a748d758e1f3dd4bdf36c045fc30113043fe50) of vlad's fork. 
In every case they all worked, even when there was a theme applied.