### PR TITLE
关于模板(大量提示词)输入新功能的PR

### DIFF
--- a/javascript/__globals.js
+++ b/javascript/__globals.js
@@ -14,6 +14,7 @@ var embeddings = [];
 var hypernetworks = [];
 var loras = [];
 var lycos = [];
+var chants = [];
 
 // Selected model info for black/whitelisting
 var currentModelHash = "";

--- a/javascript/_result.js
+++ b/javascript/_result.js
@@ -10,7 +10,8 @@ const ResultType = Object.freeze({
     "yamlWildcard": 6,
     "hypernetwork": 7,
     "lora": 8,
-    "lyco": 9
+    "lyco": 9,
+    "chant": 10
 });
 
 // Class to hold result data and annotations to make it clearer to use

--- a/javascript/ext_chants.js
+++ b/javascript/ext_chants.js
@@ -1,12 +1,12 @@
-const CHANT_REGEX = /%(?!c:)[^,> ]*>?/gg;
+const CHANT_REGEX = /<(?!e:|h:|l:)[^,> ]*>?/g;
 const CHANT_TRIGGER = () => TAC_CFG.useChants && tagword.match(CHANT_REGEX);
 
 class ChantParser extends BaseTagParser {
     parse() {
         // Show Chant
         let tempResults = [];
-        if (tagword !== "%" && tagword !== "%c:") {
-            let searchTerm = tagword.replace("%c:", "").replace("%", "");
+        if (tagword !== "<" && tagword !== "<c:") {
+            let searchTerm = tagword.replace("<c:", "").replace("<", "");
             let filterCondition = x => x.term.toLowerCase().includes(searchTerm);
             tempResults = loras.filter(x => filterCondition(x)); // Filter by tagword
         } else {
@@ -16,8 +16,8 @@ class ChantParser extends BaseTagParser {
         // Add final results
         let finalResults = [];
         tempResults.forEach(t => {
-            let result = new AutocompleteResult(t.content.trim(), ResultType.json)
-            result.meta = t.name;
+            let result = new AutocompleteResult(t.content.trim(), ResultType.chant)
+            result.meta = t.name + " Chant";
             finalResults.push(result);
         });
 
@@ -37,8 +37,7 @@ async function load() {
 
 function sanitize(tagType, text) {
     if (tagType === ResultType.chant) {
-        let selected = chants.find(x => x.content === text);
-        return `%c:${selected.term}:${TAC_CFG.extraNetworksDefaultMultiplier}>`;
+        return text.replace(/^.*?: /g, "");
     }
     return null;
 }

--- a/javascript/ext_chants.js
+++ b/javascript/ext_chants.js
@@ -1,0 +1,50 @@
+const CHANT_REGEX = /%(?!c:)[^,> ]*>?/gg;
+const CHANT_TRIGGER = () => TAC_CFG.useChants && tagword.match(CHANT_REGEX);
+
+class ChantParser extends BaseTagParser {
+    parse() {
+        // Show Chant
+        let tempResults = [];
+        if (tagword !== "%" && tagword !== "%c:") {
+            let searchTerm = tagword.replace("%c:", "").replace("%", "");
+            let filterCondition = x => x.term.toLowerCase().includes(searchTerm);
+            tempResults = loras.filter(x => filterCondition(x)); // Filter by tagword
+        } else {
+            tempResults = chants;
+        }
+
+        // Add final results
+        let finalResults = [];
+        tempResults.forEach(t => {
+            let result = new AutocompleteResult(t.content.trim(), ResultType.json)
+            result.meta = t.name;
+            finalResults.push(result);
+        });
+
+        return finalResults;
+    }
+}
+
+async function load() {
+    if (chants.length === 0) {
+        try {
+            chants = await readFile(`${tagBasePath}/chants.json`, true);
+        } catch (e) {
+            console.error("Error loading chants.txt: " + e);
+        }
+    }
+}
+
+function sanitize(tagType, text) {
+    if (tagType === ResultType.chant) {
+        let selected = chants.find(x => x.content === text);
+        return `%c:${selected.term}:${TAC_CFG.extraNetworksDefaultMultiplier}>`;
+    }
+    return null;
+}
+
+PARSERS.push(new ChantParser(CHANT_TRIGGER));
+
+// Add our utility functions to their respective queues
+QUEUE_FILE_LOAD.push(load);
+QUEUE_SANITIZE.push(sanitize);

--- a/javascript/ext_chants.js
+++ b/javascript/ext_chants.js
@@ -7,7 +7,7 @@ class ChantParser extends BaseTagParser {
         let tempResults = [];
         if (tagword !== "<" && tagword !== "<c:") {
             let searchTerm = tagword.replace("<c:", "").replace("<", "");
-            let filterCondition = x => x.term.toLowerCase().includes(searchTerm);
+            let filterCondition = x => x.terms.toLowerCase().includes(searchTerm);
             tempResults = chants.filter(x => filterCondition(x)); // Filter by tagword
         } else {
             tempResults = chants;
@@ -17,7 +17,7 @@ class ChantParser extends BaseTagParser {
         let finalResults = [];
         tempResults.forEach(t => {
             let result = new AutocompleteResult(t.content.trim(), ResultType.chant)
-            result.meta = " Chant";
+            result.meta = "Chant";
             result.type = ResultType.chant;
             result.aliases = t.name;
             result.category = t.color;

--- a/javascript/ext_chants.js
+++ b/javascript/ext_chants.js
@@ -17,7 +17,10 @@ class ChantParser extends BaseTagParser {
         let finalResults = [];
         tempResults.forEach(t => {
             let result = new AutocompleteResult(t.content.trim(), ResultType.chant)
-            result.meta = t.name + " Chant";
+            result.meta = " Chant";
+            result.type = ResultType.chant;
+            result.aliases = t.name;
+            result.category = t.color;
             finalResults.push(result);
         });
 

--- a/javascript/ext_chants.js
+++ b/javascript/ext_chants.js
@@ -8,7 +8,7 @@ class ChantParser extends BaseTagParser {
         if (tagword !== "<" && tagword !== "<c:") {
             let searchTerm = tagword.replace("<c:", "").replace("<", "");
             let filterCondition = x => x.term.toLowerCase().includes(searchTerm);
-            tempResults = loras.filter(x => filterCondition(x)); // Filter by tagword
+            tempResults = chants.filter(x => filterCondition(x)); // Filter by tagword
         } else {
             tempResults = chants;
         }

--- a/javascript/ext_embeddings.js
+++ b/javascript/ext_embeddings.js
@@ -1,4 +1,4 @@
-const EMB_REGEX = /<(?!l:|h:)[^,> ]*>?/g;
+const EMB_REGEX = /<(?!l:|h:|c:)[^,> ]*>?/g;
 const EMB_TRIGGER = () => TAC_CFG.useEmbeddings && tagword.match(EMB_REGEX);
 
 class EmbeddingParser extends BaseTagParser {

--- a/javascript/ext_hypernets.js
+++ b/javascript/ext_hypernets.js
@@ -1,4 +1,4 @@
-const HYP_REGEX = /<(?!e:|l:)[^,> ]*>?/g;
+const HYP_REGEX = /<(?!e:|l:|c:)[^,> ]*>?/g;
 const HYP_TRIGGER = () => TAC_CFG.useHypernetworks && tagword.match(HYP_REGEX);
 
 class HypernetParser extends BaseTagParser {

--- a/javascript/ext_loras.js
+++ b/javascript/ext_loras.js
@@ -1,4 +1,4 @@
-const LORA_REGEX = /<(?!e:|h:)[^,> ]*>?/g;
+const LORA_REGEX = /<(?!e:|h:|c:)[^,> ]*>?/g;
 const LORA_TRIGGER = () => TAC_CFG.useLoras && tagword.match(LORA_REGEX);
 
 class LoraParser extends BaseTagParser {

--- a/javascript/ext_lycos.js
+++ b/javascript/ext_lycos.js
@@ -1,4 +1,4 @@
-const LYCO_REGEX = /<(?!e:|h:)[^,> ]*>?/g;
+const LYCO_REGEX = /<(?!e:|h:|c:)[^,> ]*>?/g;
 const LYCO_TRIGGER = () => TAC_CFG.useLycos && tagword.match(LYCO_REGEX);
 
 class LycoParser extends BaseTagParser {

--- a/javascript/tagAutocomplete.js
+++ b/javascript/tagAutocomplete.js
@@ -403,8 +403,11 @@ function addResultsToList(textArea, results, tagword, resetList) {
         itemText.classList.add("acListItem");
 
         let displayText = "";
+        if(result.type === ResultType.chant) {
+            displayText = escapeHTML(result.aliases);
+        }
         // If the tag matches the tagword, we don't need to display the alias
-        if (result.aliases && !result.text.includes(tagword)) { // Alias
+        else if (result.aliases && !result.text.includes(tagword)) { // Alias
             let splitAliases = result.aliases.split(",");
             let bestAlias = splitAliases.find(a => a.toLowerCase().includes(tagword));
 

--- a/javascript/tagAutocomplete.js
+++ b/javascript/tagAutocomplete.js
@@ -145,6 +145,7 @@ async function syncOptions() {
         useEmbeddings: opts["tac_useEmbeddings"],
         useHypernetworks: opts["tac_useHypernetworks"],
         useLoras: opts["tac_useLoras"],
+        useChants: opts["tac_useChants"],
 	useLycos: opts["tac_useLycos"],
         showWikiLinks: opts["tac_showWikiLinks"],
         // Insertion related settings

--- a/scripts/tag_autocomplete_helper.py
+++ b/scripts/tag_autocomplete_helper.py
@@ -287,6 +287,7 @@ def on_ui_settings():
     shared.opts.add_option("tac_showAllResults", shared.OptionInfo(False, "Show all results", section=TAC_SECTION))
     shared.opts.add_option("tac_resultStepLength", shared.OptionInfo(100, "How many results to load at once", section=TAC_SECTION))
     shared.opts.add_option("tac_delayTime", shared.OptionInfo(100, "Time in ms to wait before triggering completion again (Requires restart)", section=TAC_SECTION))
+    shared.opts.add_option("tac_useChants", shared.OptionInfo(True, "Search for Chants", section=TAC_SECTION))
     shared.opts.add_option("tac_useWildcards", shared.OptionInfo(True, "Search for wildcards", section=TAC_SECTION))
     shared.opts.add_option("tac_useEmbeddings", shared.OptionInfo(True, "Search for embeddings", section=TAC_SECTION))
     shared.opts.add_option("tac_useHypernetworks", shared.OptionInfo(True, "Search for hypernetworks", section=TAC_SECTION))

--- a/tags/chants.json
+++ b/tags/chants.json
@@ -1,8 +1,32 @@
 [
     {
-        "name": "大绚丽术",
-        "terms": "大绚丽术",
-        "content": "bloom, shine",
+        "name": "Basic-NegitivePrompt",
+        "terms": "Basic,Negitive,Low,Quality",
+        "content": "(worst quality, low quality, normal quality)",
+        "color": 3
+    },
+    {
+        "name": "Basic-HighQuality",
+        "terms": "Basic,Best,Quality",
+        "content": "(masterpiece, best quality, high quality, highres, ultra-detailed)",
         "color": 1
+    },
+    {
+        "name": "Basic-Start",
+        "terms": "Basic, Start, Simple, Demo",
+        "content": "(masterpiece, best quality, high quality, highres), 1girl, extremely beautiful detailed face,  short curly hair, light smile, flower dress, outdoors, leaf, tree, best showdow",
+        "color": 5
+    },
+    {
+        "name": "Fancy-FireMagic",
+        "terms": "Fire, Magic, Fancy",
+        "content": "(extremely detailed CG unity 8k wallpaper),(masterpiece), (best quality), (ultra-detailed), (best illustration),(best shadow), (an extremely delicate and beautiful),  dynamic angle, floating, finely detail, (bloom), (shine), glinting stars, classic, (painting), (sketch),\n\na girl, solo, bare shoulders, flat_chest, diamond and glaring eyes, beautiful detailed cold face, very long blue and sliver hair, floating black feathers, wavy hair, extremely delicate and beautiful girls, beautiful detailed eyes, glowing eyes,\n\npalace, the best building, ((Fire butterflies, Flying sparks, Flames))",
+        "color": 5
+    },
+    {
+        "name": "Fancy-WaterMagic",
+        "terms": "Water, Magic, Fancy",
+        "content": "(extremely detailed CG unity 8k wallpaper),(masterpiece), (best quality), (ultra-detailed), (best illustration),(best shadow), (an extremely delicate and beautiful),  classic, dynamic angle, floating, finely detail, Depth of field, classic, (painting), (sketch), (bloom), (shine), glinting stars,\n\na girl, solo, bare shoulders, flat_chest, diamond and glaring eyes, beautiful detailed cold face, very long blue and sliver hair, floating black feathers, wavy hair, extremely delicate and beautiful girls, beautiful detailed eyes, glowing eyes,\n\nriver, (forest),palace, (fairyland,feather,flowers, nature),(sunlight),Hazy fog, mist",
+        "color": 5
     }
 ]

--- a/tags/chants.json
+++ b/tags/chants.json
@@ -1,0 +1,8 @@
+[
+    {
+        "name": "大绚丽术",
+        "terms": "大绚丽术",
+        "content": "bloom, shine",
+        "color": 1
+    }
+]


### PR DESCRIPTION
您好, DominikDoom:

首先, 感谢您的卓越贡献.

最近,我为 tagcomplete 写了一个新功能, 用来一次性填入大量的提示词, 提高提示词的输入效率. 这里我称之为"Chant".

它基于其他扩展代码开发, 几乎没有做破坏性的修改, 除了在 [tagAutocomplete.js](https://github.com/DominikDoom/a1111-sd-webui-tagcomplete/compare/main...fuyedong:a1111-sd-webui-tagcomplete:main#diff-2ce6765e9d5de7544b10d788d61a36f14ca1f2b11a4473d02dcac2972f813fe8)中做了一些展示方面的针对性的优化.

该功能首先需要在 `tags` 目录下新增一个名为 `chants.json` 的JSON文件. 

该JSON格式为 `[chantObject1, chantObject2...chantObjectn]` 格式.

chantObject 有四个字段:

- `name` - 用于展示
- `terms` - 用于搜索,
- `content` - 实际的提示词内容
- `color` - 颜色.

以下是json文件的示例:

```json
[
    {
        "name": "大绚丽术",
        "terms": "大绚丽术",
        "content": "bloom, shine",
        "color": 1
    },
    {
        "name": "Base High Quality",
        "terms": "High Quality, Base",
        "content": "(extremely detailed CG unity 8k wallpaper, masterpiece, best quality, ultra-detailed), ",
        "color": 2
    },
]
```

通过输入 `<` 和 `<c:` 指令触发输入, 例如在提示词框中输入 `<c:高质量`, 选中后生成以下提示词

```clojure
(masterpiece, best quality, high quality, highres, ultra-detailed), 
```

不知道该功能是否符合 tagcomplete 的项目需求, 并合并到 tagcomplete 中呢?

期待您的接受