### PR TITLE
POC: Updating loras on the fly.

### DIFF
--- a/javascript/ext_loras.js
+++ b/javascript/ext_loras.js
@@ -37,6 +37,16 @@ async function load() {
     }
 }
 
+async function lora_reload() {
+    try {
+        loras = (await readFile(`${tagBasePath}/temp/lora.txt`)).split("\n")
+            .filter(x => x.trim().length > 0) // Remove empty lines
+            .map(x => x.trim()); // Remove carriage returns and padding if it exists
+    } catch (e) {
+        console.error("Error loading lora.txt: " + e);
+    }
+}
+
 function sanitize(tagType, text) {
     if (tagType === ResultType.lora) {
         return `<lora:${text}:${TAC_CFG.extraNetworksDefaultMultiplier}>`;

--- a/scripts/tag_autocomplete_helper.py
+++ b/scripts/tag_autocomplete_helper.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import gradio as gr
 import yaml
 from modules import script_callbacks, scripts, sd_hijack, shared
+import modules # SBM Reload lora ui.
 
 try:
     from modules.paths import extensions_dir, script_path
@@ -39,6 +40,37 @@ try:
     LYCO_PATH = Path(shared.cmd_opts.lyco_dir)
 except AttributeError:
     LYCO_PATH = None
+
+def lora_update():
+    if LORA_PATH is not None and LORA_PATH.exists():
+        lora = get_lora()
+        if lora:
+            write_to_temp_file('lora.txt', lora)
+        
+class Script(modules.scripts.Script):
+    def __init__(self):
+        self.spam = True
+
+    def title(self):
+        return "Tag autocomplete"
+
+    def show(self, is_img2img):
+        return modules.scripts.AlwaysVisible
+
+    infotext_fields = None
+    paste_field_names = []
+
+    def ui(self, is_img2img):
+        with gr.Accordion("Autocomplete", open=False, elem_id="AC_main"):
+            with gr.Row():
+                btnrelora1 = gr.Button("Update loras")
+                btnrelora2 = gr.Button("Reload loras")
+                btnrelora3 = gr.Button("Update + reload - js needs to wait?")
+            btnrelora1.click(lora_update, inputs = [], outputs = [])
+            btnrelora2.click(lambda x: x, _js = "lora_reload", inputs = [], outputs = [])
+            btnrelora3.click(lora_update, _js = "lora_reload", inputs = [], outputs = [])
+        
+        return [btnrelora1, btnrelora2, btnrelora3]
 
 def find_ext_wildcard_paths():
     """Returns the path to the extension wildcards folder"""


### PR DESCRIPTION
Hello dominik, it's been a longstanding peeve of mine that the ui must be restarted to see newly added loras in autocomplete.
Apparently, merely updating the lora.txt file and the global loras variable is all it takes to refresh the list, no restart needed (at least on vlad's fork). So I added a couple crummy ui buttons and copypastad functions, and it seems to be working almost without a hitch (I think the button's js call doesn't wait for the file to update, so possibly need a timer to combine that).
I'm also using a slightly modded version which has direct instead of relative paths and gradio's circumvented to allow said path, but if that's all it takes to enable this feature, then I think it's imperative to find a way to do that.
Penny for your thoughts?