### PR TITLE
Add adetailer to text areas.

### DIFF
--- a/javascript/_textAreas.js
+++ b/javascript/_textAreas.js
@@ -9,7 +9,9 @@ const core = [
     "#img2img_prompt > label > textarea",
     "#txt2img_neg_prompt > label > textarea",
     "#img2img_neg_prompt > label > textarea",
-    ".prompt > label > textarea"
+    ".prompt > label > textarea",
+	"#script_txt2img_adetailer_ad_prompt > label > textarea", // Adetailer.
+	"#script_txt2img_adetailer_ad_negative_prompt > label > textarea",
 ];
 
 // Third party text area selectors


### PR DESCRIPTION
I haven't followed the difference between core and third party or pos / neg down the road, but it seems to be working for me with just these two lines, and I think you have a failsafe for nonexistent areas in getTextAreas? 