### PR TITLE
Embedding forced reload.

### DIFF
--- a/scripts/tag_autocomplete_helper.py
+++ b/scripts/tag_autocomplete_helper.py
@@ -22,7 +22,7 @@ try:
     load_textual_inversion_embeddings = sd_hijack.model_hijack.embedding_db.load_textual_inversion_embeddings
 except Exception as e: # Not supported.
     load_textual_inversion_embeddings = lambda *args, **kwargs: None
-    print("Cannot load embeddings instantly:", e)
+    print("Tag Autocomplete: Cannot reload embeddings instantly:", e)
 
 def get_wildcards():
     """Returns a list of all wildcards. Works on nested folders."""

--- a/scripts/tag_autocomplete_helper.py
+++ b/scripts/tag_autocomplete_helper.py
@@ -22,7 +22,7 @@ try:
     load_textual_inversion_embeddings = sd_hijack.model_hijack.embedding_db.load_textual_inversion_embeddings
 except Exception as e: # Not supported.
     load_textual_inversion_embeddings = lambda *args, **kwargs: None
-    print("Cannot load embeddings instantly: ", e)
+    print("Cannot load embeddings instantly:", e)
 
 def get_wildcards():
     """Returns a list of all wildcards. Works on nested folders."""

--- a/scripts/tag_autocomplete_helper.py
+++ b/scripts/tag_autocomplete_helper.py
@@ -17,6 +17,12 @@ from scripts.model_keyword_support import (get_lora_simple_hash,
                                            write_model_keyword_path)
 from scripts.shared_paths import *
 
+# Attempt to get embedding load function, using the same call as api.
+try:
+    load_textual_inversion_embeddings = sd_hijack.model_hijack.embedding_db.load_textual_inversion_embeddings
+except Exception as e: # Not supported.
+    load_textual_inversion_embeddings = lambda *args, **kwargs: None
+    print("Cannot load embeddings instantly: ", e)
 
 def get_wildcards():
     """Returns a list of all wildcards. Works on nested folders."""
@@ -280,6 +286,7 @@ if EMB_PATH.exists():
 def refresh_temp_files():
     global WILDCARD_EXT_PATHS
     WILDCARD_EXT_PATHS = find_ext_wildcard_paths()
+    load_textual_inversion_embeddings(force_reload = True) # Instant embedding reload.
     write_temp_files()
     get_embeddings(shared.sd_model)
 


### PR DESCRIPTION
Hey dom, been having some trouble with getting embeddings to reload on the latest webui.
I found this method `load_textual_inversion_embeddings` which can be called to reload embeddings instantly, adding it to refresh_temp_files seems to do the trick for me.
The force_reload might not be necessary but I think it's better to be sure we're refreshing. I'm not sure whether auto's architecture on this is the same as vlad's (and of course in legacy versions), so I added an exception and dummified the function in such cases.