### PR TITLE
lyco_path fix

### DIFF
--- a/scripts/shared_paths.py
+++ b/scripts/shared_paths.py
@@ -30,7 +30,7 @@ except AttributeError:
     LORA_PATH = None
 
 try:
-    LYCO_PATH = Path(shared.cmd_opts.lyco_dir)
+    LYCO_PATH = Path(shared.cmd_opts.lyco_dir_backcompat)
 except AttributeError:
     LYCO_PATH = None
 


### PR DESCRIPTION
This fixes the extension not finding any LyCORIS model in './models/LyCORIS/' (a1111 v1.6.0).