### PR TITLE
Add listener for extra network refresh button

### DIFF
--- a/javascript/tagAutocomplete.js
+++ b/javascript/tagAutocomplete.js
@@ -1326,6 +1326,11 @@ async function setup() {
     // Listener for internal temp files refresh button
     gradioApp().querySelector("#refresh_tac_refreshTempFiles")?.addEventListener("click", refreshTacTempFiles);
 
+    // Also add listener for external network refresh button
+    gradioApp().querySelector("#txt2img_extra_refresh")?.addEventListener("click", refreshTacTempFiles);
+    gradioApp().querySelector("#img2img_extra_refresh")?.addEventListener("click", refreshTacTempFiles);
+
+
     // Add mutation observer for the model hash text to also allow hash-based blacklist again
     let modelHashText = gradioApp().querySelector("#sd_checkpoint_hash");
     updateModelName();

--- a/javascript/tagAutocomplete.js
+++ b/javascript/tagAutocomplete.js
@@ -1324,12 +1324,15 @@ async function setup() {
         })
     });
     // Listener for internal temp files refresh button
-    gradioApp().querySelector("#refresh_tac_refreshTempFiles")?.addEventListener("click", refreshTacTempFiles);
+    const refreshButton = gradioApp().querySelector("#refresh_tac_refreshTempFiles")
+    refreshButton?.addEventListener("click", refreshTacTempFiles);
 
-    // Also add listener for external network refresh button
-    gradioApp().querySelector("#txt2img_extra_refresh")?.addEventListener("click", refreshTacTempFiles);
-    gradioApp().querySelector("#img2img_extra_refresh")?.addEventListener("click", refreshTacTempFiles);
-
+    // Also add listener for external network refresh button (plus triggering python code)
+    ["#img2img_extra_refresh", "#txt2img_extra_refresh"].forEach(e => {
+        gradioApp().querySelector(e)?.addEventListener("click", ()=>{
+            refreshButton?.click();
+        });
+    })
 
     // Add mutation observer for the model hash text to also allow hash-based blacklist again
     let modelHashText = gradioApp().querySelector("#sd_checkpoint_hash");


### PR DESCRIPTION
When user click refresh for lora, textual inversion, etc., also refresh TAC tempfiles so that it keeps synchronized between the two.