### PR TITLE
Attempt to use the build-in Lora.networks Lora/LyCORIS models lists

### DIFF
--- a/scripts/shared_paths.py
+++ b/scripts/shared_paths.py
@@ -30,7 +30,10 @@ except AttributeError:
     LORA_PATH = None
 
 try:
-    LYCO_PATH = Path(shared.cmd_opts.lyco_dir_backcompat)
+    try:
+        LYCO_PATH = Path(shared.cmd_opts.lyco_dir_backcompat)
+    except:
+        LYCO_PATH = Path(shared.cmd_opts.lyco_dir) # attempt original non-backcompat path
 except AttributeError:
     LYCO_PATH = None
 

--- a/scripts/tag_autocomplete_helper.py
+++ b/scripts/tag_autocomplete_helper.py
@@ -235,53 +235,48 @@ try:
     import importlib
     lora_networks = importlib.import_module("extensions-builtin.Lora.networks")
     
-    LORA_PATH_ABSPATH = os.path.abspath(LORA_PATH)
+    LORA_ABSPATH = LORA_PATH.absolute()
 
     def _get_lora() -> List[Path]:
         return [ 
-            Path(lora_networks.available_networks[name].filename).relative_to(os.getcwd())
+            Path(lora_networks.available_networks[name].filename)
+                .relative_to(os.getcwd())
             for name 
             in lora_networks.available_networks
-            if str(
-                os.path.abspath(
-                    lora_networks.available_networks[name].filename
-                )
-            ).startswith(
-                LORA_PATH_ABSPATH
-            )
+            if Path(lora_networks.available_networks[name].filename)
+                .absolute()
+                .is_relative_to(LORA_ABSPATH)
         ]
-    
-    LYCO_PATH_ABSPATH = os.path.abspath(LYCO_PATH)
+   
+    LYCO_ABSPATH = LYCO_PATH.absolute()
 
+    '''
+    needed for edge-case where user has opted out of having the Lora Extension
+    handle LyCORIS networks, will trigger fallback
+    '''
     assert any(
-        str(
-            os.path.abspath(
-                lora_networks.available_networks[name].filename
-            )
-        ).startswith(
-            LYCO_PATH_ABSPATH
-        )
+        Path(lora_networks.available_networks[name].filename)
+            .absolute()
+            .is_relative_to(LYCO_ABSPATH)
         for name 
         in lora_networks.available_networks
     ), 'the Lora Extension does not handle LyCORIS models'
 
-    
     def _get_lyco() -> List[Path]:
         return [ 
-            Path(lora_networks.available_networks[name].filename).relative_to(os.getcwd())
+            Path(lora_networks.available_networks[name].filename)
+                .relative_to(os.getcwd())
             for name 
             in lora_networks.available_networks
-            if str(
-                os.path.abspath(
-                    lora_networks.available_networks[name].filename
-                )
-            ).startswith(
-                LYCO_PATH_ABSPATH
-            )
+            if Path(lora_networks.available_networks[name].filename)
+                .absolute()
+                .is_relative_to(LYCO_ABSPATH)
         ]
     
 except Exception as e:
-    print(f'Exception setting-up performant fetchers: {e}')
+    pass
+    # no need to report
+    # print(f'Exception setting-up performant fetchers: {e}')
 
 def get_lora():
     """Write a list of all lora"""

--- a/scripts/tag_autocomplete_helper.py
+++ b/scripts/tag_autocomplete_helper.py
@@ -11,7 +11,6 @@ import yaml
 from fastapi import FastAPI
 from fastapi.responses import FileResponse, JSONResponse
 from modules import script_callbacks, sd_hijack, shared, hashes
-from typing_extensions import List
 
 from scripts.model_keyword_support import (get_lora_simple_hash,
                                            load_hash_cache, update_hash_cache,

--- a/scripts/tag_autocomplete_helper.py
+++ b/scripts/tag_autocomplete_helper.py
@@ -239,36 +239,24 @@ try:
 
     def _get_lora() -> List[Path]:
         return [ 
-            Path(lora_networks.available_networks[name].filename)
+            Path(model.filename)
                 .relative_to(os.getcwd())
-            for name 
-            in lora_networks.available_networks
-            if Path(lora_networks.available_networks[name].filename)
+            for model
+            in lora_networks.available_networks.values()
+            if Path(model.filename)
                 .absolute()
                 .is_relative_to(LORA_ABSPATH)
         ]
    
     LYCO_ABSPATH = LYCO_PATH.absolute()
 
-    '''
-    needed for edge-case where user has opted out of having the Lora Extension
-    handle LyCORIS networks, will trigger fallback
-    '''
-    assert any(
-        Path(lora_networks.available_networks[name].filename)
-            .absolute()
-            .is_relative_to(LYCO_ABSPATH)
-        for name 
-        in lora_networks.available_networks
-    ), 'the Lora Extension does not handle LyCORIS models'
-
     def _get_lyco() -> List[Path]:
         return [ 
-            Path(lora_networks.available_networks[name].filename)
+            Path(model.filename)
                 .relative_to(os.getcwd())
-            for name 
-            in lora_networks.available_networks
-            if Path(lora_networks.available_networks[name].filename)
+            for model
+            in lora_networks.available_networks.values()
+            if Path(model.filename)
                 .absolute()
                 .is_relative_to(LYCO_ABSPATH)
         ]

--- a/scripts/tag_autocomplete_helper.py
+++ b/scripts/tag_autocomplete_helper.py
@@ -3,7 +3,6 @@
 
 import glob
 import json
-import os
 import urllib.parse
 from pathlib import Path
 
@@ -205,7 +204,7 @@ def get_hypernetworks():
 
 model_keyword_installed = write_model_keyword_path()
 
-def _get_lora() -> List[Path]: 
+def _get_lora(): 
     """Write a list of all lora"""
     global model_keyword_installed
 
@@ -216,7 +215,7 @@ def _get_lora() -> List[Path]:
 
     return valid_loras
 
-def _get_lyco() -> List[Path]: 
+def _get_lyco(): 
 
     """Write a list of all LyCORIS/LOHA from https://github.com/KohakuBlueleaf/a1111-sd-webui-lycoris"""
 
@@ -237,10 +236,10 @@ try:
     
     LORA_ABSPATH = LORA_PATH.absolute()
 
-    def _get_lora() -> List[Path]:
+    def _get_lora():
         return [ 
             Path(model.filename)
-                .relative_to(os.getcwd())
+                .relative_to(FILE_DIR)
             for model
             in lora_networks.available_networks.values()
             if Path(model.filename)
@@ -250,10 +249,10 @@ try:
    
     LYCO_ABSPATH = LYCO_PATH.absolute()
 
-    def _get_lyco() -> List[Path]:
+    def _get_lyco():
         return [ 
             Path(model.filename)
-                .relative_to(os.getcwd())
+                .relative_to(FILE_DIR)
             for model
             in lora_networks.available_networks.values()
             if Path(model.filename)


### PR DESCRIPTION
This is a small performance patch for `SD.Next`.  This attempts to load and use the built-in `Lora.networks` Lora/LyCORIS Models lists, so as not to duplicate the work that has already been done.  This is not much of an issue on small collections, but I have a relatively large collection, and this cut the extension's load time from +200 seconds to ~20 seconds.

Work in `shared_paths` is a comparability patch to continue working with SD.Next if you have a separate `LyCORIS` directory still.

I have not tested with the "OG" A1111 WebUI, only SD.Next.  I have been using this patch daily for a week or so now (the non `backcompat` is new, but the rest I have been using for a bit now), and it does seem to work well.