### PR TITLE
Light/Dark mode text color for visibility.

### DIFF
--- a/javascript/tagAutocomplete.js
+++ b/javascript/tagAutocomplete.js
@@ -723,6 +723,11 @@ function addResultsToList(textArea, results, tagword, resetList) {
                 cat = "-1";
 
             flexDiv.style = `color: ${colorGroup[cat][mode]};`;
+        } else {
+            light_dark = [
+                'lightslategray', 'darkslategray'
+            ]
+            flexDiv.style = `color: ${light_dark[mode]};`;
         }
 
         // Post count


### PR DESCRIPTION
Small patch to account for the drop-down text color in SD.Next Light/Dark mode(s).  The default cascading color ends up as white, on a white background.  Using shades of gray (and alternating for Light or Dark mode) ensures visibility in both scenarios, and fixes default visibility.

Not tested in standard A1111