### PR TITLE
[Feature] Wildcard model name search.

### DIFF
--- a/javascript/ext_chants.js
+++ b/javascript/ext_chants.js
@@ -3,7 +3,7 @@ const CHANT_TRIGGER = () => TAC_CFG.chantFile && TAC_CFG.chantFile !== "None" &&
 
 function escapeRegex(text) {
     // Escape all characters except asterisks.
-    return text.replace(/[-[\]{}()+?.,\\^$|#\s]/g, '\\$&').replace(/\*/g, '.*');
+    return text.replace(/[-[\]{}()+.,\\^$|#\s]/g, '\\$&').replace(/\*/g, '.*').replace(/\?/g, '.');
 }
 class ChantParser extends BaseTagParser {
     parse() {

--- a/javascript/ext_chants.js
+++ b/javascript/ext_chants.js
@@ -1,13 +1,20 @@
 const CHANT_REGEX = /<(?!e:|h:|l:)[^,> ]*>?/g;
 const CHANT_TRIGGER = () => TAC_CFG.chantFile && TAC_CFG.chantFile !== "None" && tagword.match(CHANT_REGEX);
 
+function escapeRegex(text) {
+    // Escape all characters except asterisks.
+    return text.replace(/[-[\]{}()+?.,\\^$|#\s]/g, '\\$&').replace(/\*/g, '.*');
+}
 class ChantParser extends BaseTagParser {
     parse() {
         // Show Chant
         let tempResults = [];
         if (tagword !== "<" && tagword !== "<c:") {
             let searchTerm = tagword.replace("<chant:", "").replace("<c:", "").replace("<", "");
-            let filterCondition = x => x.terms.toLowerCase().includes(searchTerm) || x.name.toLowerCase().includes(searchTerm);
+            let filterCondition = x => {
+                let regex = new RegExp(escapeRegex(searchTerm), 'i');
+                return regex.test(x.terms.toLowerCase()) || regex.test(x.name.toLowerCase());
+            };
             tempResults = chants.filter(x => filterCondition(x)); // Filter by tagword
         } else {
             tempResults = chants;

--- a/javascript/ext_embeddings.js
+++ b/javascript/ext_embeddings.js
@@ -3,7 +3,7 @@ const EMB_TRIGGER = () => TAC_CFG.useEmbeddings && (tagword.match(EMB_REGEX) || 
 
 function escapeRegex(text) {
     // Escape all characters except asterisks.
-    return text.replace(/[-[\]{}()+?.,\\^$|#\s]/g, '\\$&').replace(/\*/g, '.*');
+    return text.replace(/[-[\]{}()+.,\\^$|#\s]/g, '\\$&').replace(/\*/g, '.*').replace(/\?/g, '.');
 }
 class EmbeddingParser extends BaseTagParser {
     parse() {

--- a/javascript/ext_embeddings.js
+++ b/javascript/ext_embeddings.js
@@ -1,6 +1,10 @@
 const EMB_REGEX = /<(?!l:|h:|c:)[^,> ]*>?/g;
 const EMB_TRIGGER = () => TAC_CFG.useEmbeddings && (tagword.match(EMB_REGEX) || TAC_CFG.includeEmbeddingsInNormalResults);
 
+function escapeRegex(text) {
+    // Escape all characters except asterisks.
+    return text.replace(/[-[\]{}()+?.,\\^$|#\s]/g, '\\$&').replace(/\*/g, '.*');
+}
 class EmbeddingParser extends BaseTagParser {
     parse() {
         // Show embeddings
@@ -16,7 +20,10 @@ class EmbeddingParser extends BaseTagParser {
                 searchTerm = searchTerm.slice(3);
             }
 
-            let filterCondition = x => x[0].toLowerCase().includes(searchTerm) || x[0].toLowerCase().replaceAll(" ", "_").includes(searchTerm);
+            let filterCondition = x => {
+                let regex = new RegExp(escapeRegex(searchTerm), 'i');
+                return regex.test(x[0].toLowerCase()) || regex.test(x[0].toLowerCase().replaceAll(" ", "_"));
+            };
 
             if (versionString)
                 tempResults = embeddings.filter(x => filterCondition(x) && x[2] && x[2].toLowerCase() === versionString.toLowerCase()); // Filter by tagword

--- a/javascript/ext_hypernets.js
+++ b/javascript/ext_hypernets.js
@@ -1,13 +1,20 @@
 const HYP_REGEX = /<(?!e:|l:|c:)[^,> ]*>?/g;
 const HYP_TRIGGER = () => TAC_CFG.useHypernetworks && tagword.match(HYP_REGEX);
 
+function escapeRegex(text) {
+    // Escape all characters except asterisks.
+    return text.replace(/[-[\]{}()+?.,\\^$|#\s]/g, '\\$&').replace(/\*/g, '.*');
+}
 class HypernetParser extends BaseTagParser {
     parse() {
         // Show hypernetworks
         let tempResults = [];
         if (tagword !== "<" && tagword !== "<h:" && tagword !== "<hypernet:") {
             let searchTerm = tagword.replace("<hypernet:", "").replace("<h:", "").replace("<", "");
-            let filterCondition = x => x.toLowerCase().includes(searchTerm) || x.toLowerCase().replaceAll(" ", "_").includes(searchTerm);
+            let filterCondition = x => {
+                let regex = new RegExp(escapeRegex(searchTerm), 'i');
+                return regex.test(x.toLowerCase()) || regex.test(x.toLowerCase().replaceAll(" ", "_"));
+            };
             tempResults = hypernetworks.filter(x => filterCondition(x[0])); // Filter by tagword
         } else {
             tempResults = hypernetworks;

--- a/javascript/ext_hypernets.js
+++ b/javascript/ext_hypernets.js
@@ -3,7 +3,7 @@ const HYP_TRIGGER = () => TAC_CFG.useHypernetworks && tagword.match(HYP_REGEX);
 
 function escapeRegex(text) {
     // Escape all characters except asterisks.
-    return text.replace(/[-[\]{}()+?.,\\^$|#\s]/g, '\\$&').replace(/\*/g, '.*');
+    return text.replace(/[-[\]{}()+.,\\^$|#\s]/g, '\\$&').replace(/\*/g, '.*').replace(/\?/g, '.');
 }
 class HypernetParser extends BaseTagParser {
     parse() {

--- a/javascript/ext_loras.js
+++ b/javascript/ext_loras.js
@@ -3,7 +3,7 @@ const LORA_TRIGGER = () => TAC_CFG.useLoras && tagword.match(LORA_REGEX);
 
 function escapeRegex(text) {
     // Escape all characters except asterisks.
-    return text.replace(/[-[\]{}()+?.,\\^$|#\s]/g, '\\$&').replace(/\*/g, '.*');
+    return text.replace(/[-[\]{}()+.,\\^$|#\s]/g, '\\$&').replace(/\*/g, '.*').replace(/\?/g, '.');
 }
 class LoraParser extends BaseTagParser {
     parse() {

--- a/javascript/ext_loras.js
+++ b/javascript/ext_loras.js
@@ -1,13 +1,20 @@
 const LORA_REGEX = /<(?!e:|h:|c:)[^,> ]*>?/g;
 const LORA_TRIGGER = () => TAC_CFG.useLoras && tagword.match(LORA_REGEX);
 
+function escapeRegex(text) {
+    // Escape all characters except asterisks.
+    return text.replace(/[-[\]{}()+?.,\\^$|#\s]/g, '\\$&').replace(/\*/g, '.*');
+}
 class LoraParser extends BaseTagParser {
     parse() {
         // Show lora
         let tempResults = [];
         if (tagword !== "<" && tagword !== "<l:" && tagword !== "<lora:") {
             let searchTerm = tagword.replace("<lora:", "").replace("<l:", "").replace("<", "");
-            let filterCondition = x => x.toLowerCase().includes(searchTerm) || x.toLowerCase().replaceAll(" ", "_").includes(searchTerm);
+            let filterCondition = x => {
+                let regex = new RegExp(escapeRegex(searchTerm), 'i');
+                return regex.test(x.toLowerCase()) || regex.test(x.toLowerCase().replaceAll(" ", "_"));
+            };
             tempResults = loras.filter(x => filterCondition(x[0])); // Filter by tagword
         } else {
             tempResults = loras;

--- a/javascript/ext_lycos.js
+++ b/javascript/ext_lycos.js
@@ -13,7 +13,7 @@ class LycoParser extends BaseTagParser {
             let searchTerm = tagword.replace("<lyco:", "").replace("<lora:", "").replace("<l:", "").replace("<", "");
             let filterCondition = x => {
                 let regex = new RegExp(escapeRegex(searchTerm), 'i');
-                return regex.test(x) || regex.test(x.toLowerCase().replaceAll(" ", "_"));
+                return regex.test(x.toLowerCase()) || regex.test(x.toLowerCase().replaceAll(" ", "_"));
             };
             tempResults = lycos.filter(x => filterCondition(x[0])); // Filter by tagword
         } else {

--- a/javascript/ext_lycos.js
+++ b/javascript/ext_lycos.js
@@ -3,7 +3,7 @@ const LYCO_TRIGGER = () => TAC_CFG.useLycos && tagword.match(LYCO_REGEX);
 
 function escapeRegex(text) {
     // Escape all characters except asterisks.
-    return text.replace(/[-[\]{}()+?.,\\^$|#\s]/g, '\\$&').replace(/\*/g, '.*');
+    return text.replace(/[-[\]{}()+.,\\^$|#\s]/g, '\\$&').replace(/\*/g, '.*').replace(/\?/g, '.');
 }
 class LycoParser extends BaseTagParser {
     parse() {

--- a/javascript/ext_lycos.js
+++ b/javascript/ext_lycos.js
@@ -1,13 +1,20 @@
 const LYCO_REGEX = /<(?!e:|h:|c:)[^,> ]*>?/g;
 const LYCO_TRIGGER = () => TAC_CFG.useLycos && tagword.match(LYCO_REGEX);
 
+function escapeRegex(text) {
+    // Escape all characters except asterisks.
+    return text.replace(/[-[\]{}()+?.,\\^$|#\s]/g, '\\$&').replace(/\*/g, '.*');
+}
 class LycoParser extends BaseTagParser {
     parse() {
         // Show lyco
         let tempResults = [];
         if (tagword !== "<" && tagword !== "<l:" && tagword !== "<lyco:" && tagword !== "<lora:") {
             let searchTerm = tagword.replace("<lyco:", "").replace("<lora:", "").replace("<l:", "").replace("<", "");
-            let filterCondition = x => x.toLowerCase().includes(searchTerm) || x.toLowerCase().replaceAll(" ", "_").includes(searchTerm);
+            let filterCondition = x => {
+                let regex = new RegExp(escapeRegex(searchTerm), 'i');
+                return regex.test(x) || regex.test(x.toLowerCase().replaceAll(" ", "_"));
+            };
             tempResults = lycos.filter(x => filterCondition(x[0])); // Filter by tagword
         } else {
             tempResults = lycos;

--- a/javascript/ext_styles.js
+++ b/javascript/ext_styles.js
@@ -5,7 +5,7 @@ var lastStyleVarIndex = "";
 
 function escapeRegex(text) {
     // Escape all characters except asterisks.
-    return text.replace(/[-[\]{}()+?.,\\^$|#\s]/g, '\\$&').replace(/\*/g, '.*');
+    return text.replace(/[-[\]{}()+.,\\^$|#\s]/g, '\\$&').replace(/\*/g, '.*').replace(/\?/g, '.');
 }
 class StyleParser extends BaseTagParser {
    async parse() {

--- a/javascript/ext_styles.js
+++ b/javascript/ext_styles.js
@@ -18,7 +18,10 @@ class StyleParser extends BaseTagParser {
         if (tagword !== matchGroups[1]) {
             let searchTerm = tagword.replace(matchGroups[1], "");
             
-            let filterCondition = x => x[0].toLowerCase().includes(searchTerm) || x[0].toLowerCase().replaceAll(" ", "_").includes(searchTerm);
+            let filterCondition = x => {
+                let regex = new RegExp(escapeRegex(searchTerm), 'i');
+                return regex.test(x[0].toLowerCase()) || regex.test(x[0].toLowerCase().replaceAll(" ", "_"));
+            };
             tempResults = styleNames.filter(x => filterCondition(x)); // Filter by tagword
         } else {
             tempResults = styleNames;

--- a/javascript/ext_styles.js
+++ b/javascript/ext_styles.js
@@ -3,6 +3,10 @@ const STYLE_TRIGGER = () => TAC_CFG.useStyleVars && tagword.match(STYLE_REGEX);
 
 var lastStyleVarIndex = "";
 
+function escapeRegex(text) {
+    // Escape all characters except asterisks.
+    return text.replace(/[-[\]{}()+?.,\\^$|#\s]/g, '\\$&').replace(/\*/g, '.*');
+}
 class StyleParser extends BaseTagParser {
    async parse() {
         // Refresh if needed


### PR DESCRIPTION
This changes all the simple `filterCondition .includes` type checks to regex, and escapes all regex chars (probably) except for asterisks to simulate a simple wildcard search. I don't know of a better way in js.

Additional notes:
- Haven't implemented changing `?` to `.`, could be nice but I don't generally use that.
- The double includes + replaceAll calls have been copied verbatim, but would be slightly more efficient to add those as `[ _]` replacements in regex instead. And case insensitive.
- The escapeRegex function could probably be moved to BaseTagParser to remove some copypasta. Maybe filterCondition as well though the different sources look like more effort (overriding with a super call on the right property?). Up to your discretion, dom.
- I think period replacement isn't working quite right, the first one I type (ie `<.` or `<bla*.`) still seems to be ignored, only the second time filters. Might be some other part of the code though, other chars doing fine in the same format.
- Wildcard's method is a bit above my level, but if it's just supposed to be "allow partial matches before slashes" to get to specific subdirectories as I understand from the docs, a simple `\ -> .*\` pattern should do that cleanly.