### PR TITLE
[Feature] Modifier keys for list navigation.

### DIFF
--- a/javascript/tagAutocomplete.js
+++ b/javascript/tagAutocomplete.js
@@ -216,7 +216,7 @@ async function syncOptions() {
         includeEmbeddingsInNormalResults: opts["tac_includeEmbeddingsInNormalResults"],
         useHypernetworks: opts["tac_useHypernetworks"],
         useLoras: opts["tac_useLoras"],
-	    useLycos: opts["tac_useLycos"],
+        useLycos: opts["tac_useLycos"],
         useLoraPrefixForLycos: opts["tac_useLoraPrefixForLycos"],
         showWikiLinks: opts["tac_showWikiLinks"],
         showExtraNetworkPreviews: opts["tac_showExtraNetworkPreviews"],
@@ -1165,7 +1165,7 @@ function navigateInList(textArea, event) {
     if (event.altKey) modKey += "Alt+";
     if (event.shiftKey) modKey += "Shift+";
     if (event.metaKey) modKey += "Meta+";
-	modKey += event.key;
+        modKey += event.key;
 
     oldSelectedTag = selectedTag;
 
@@ -1240,8 +1240,8 @@ function navigateInList(textArea, event) {
         case keys["Close"]:
             hideResults(textArea);
             break;
-	default:
-	    if (event.ctrlKey || event.altKey || event.shiftKey || event.metaKey) return;
+        default:
+            if (event.ctrlKey || event.altKey || event.shiftKey || event.metaKey) return;
     }
     let moveKeys = [keys["MoveUp"], keys["MoveDown"], keys["JumpUp"], keys["JumpDown"], keys["JumpToStart"], keys["JumpToEnd"]];
     if (selectedTag === resultCount - 1 && moveKeys.includes(event.key)) {

--- a/javascript/tagAutocomplete.js
+++ b/javascript/tagAutocomplete.js
@@ -1159,12 +1159,17 @@ function navigateInList(textArea, event) {
 
     if (!validKeys.includes(event.key)) return;
     if (!isVisible(textArea)) return
-    // Return if ctrl key is pressed to not interfere with weight editing shortcut
-    if (event.ctrlKey || event.altKey || event.shiftKey || event.metaKey) return;
+    // Add modifier keys to base as text+.
+    let modKey = "";
+    if (event.ctrlKey) modKey += "Ctrl+";
+    if (event.altKey) modKey += "Alt+";
+    if (event.shiftKey) modKey += "Shift+";
+    if (event.metaKey) modKey += "Meta+";
+	modKey += event.key;
 
     oldSelectedTag = selectedTag;
 
-    switch (event.key) {
+    switch (modKey) {
         case keys["MoveUp"]:
             if (selectedTag === null) {
                 selectedTag = resultCount - 1;
@@ -1235,6 +1240,8 @@ function navigateInList(textArea, event) {
         case keys["Close"]:
             hideResults(textArea);
             break;
+	default:
+	    if (event.ctrlKey || event.altKey || event.shiftKey || event.metaKey) return;
     }
     let moveKeys = [keys["MoveUp"], keys["MoveDown"], keys["JumpUp"], keys["JumpDown"], keys["JumpToStart"], keys["JumpToEnd"]];
     if (selectedTag === resultCount - 1 && moveKeys.includes(event.key)) {


### PR DESCRIPTION
I've always hated home / end getting overridden. Alt+PageDown/Up are a much more useless combination.
This fix allows detecting modified keys via the standard "Ctrl+Alt+Key" syntax - instead of returning in navigation, they are prepended to the base key and checked against the list; only if not found does the function default to return.

Note: In my testing, simply returning on default regardless of modifier usage also seems to work correctly, but to prevent any breaking changes I've moved the list down there.