### PR TITLE
Embedding relative path.

### DIFF
--- a/javascript/ext_embeddings.js
+++ b/javascript/ext_embeddings.js
@@ -29,7 +29,11 @@ class EmbeddingParser extends BaseTagParser {
         // Add final results
         let finalResults = [];
         tempResults.forEach(t => {
-            let result = new AutocompleteResult(t[0].trim(), ResultType.embedding)
+            let lastDot = t[0].lastIndexOf(".") > -1 ? t[0].lastIndexOf(".") : t[0].length;
+            let lastSlash = t[0].lastIndexOf("/") > -1 ? t[0].lastIndexOf("/") : -1;
+            let name = t[0].trim().substring(lastSlash + 1, lastDot);
+
+            let result = new AutocompleteResult(name, ResultType.embedding)
             result.sortKey = t[1];
             result.meta = t[2] + " Embedding";
             finalResults.push(result);

--- a/scripts/tag_autocomplete_helper.py
+++ b/scripts/tag_autocomplete_helper.py
@@ -186,15 +186,15 @@ def get_embeddings(sd_model):
                 continue
 
             if emb.shape is None:
-                emb_unknown.append((Path(emb.filename), key, ""))
+                emb_unknown.append((Path(emb.filename), Path(emb.filename).relative_to(EMB_PATH).as_posix(), ""))
             elif emb.shape == V1_SHAPE:
-                emb_v1.append((Path(emb.filename), key, "v1"))
+                emb_v1.append((Path(emb.filename), Path(emb.filename).relative_to(EMB_PATH).as_posix(), "v1"))
             elif emb.shape == V2_SHAPE:
-                emb_v2.append((Path(emb.filename), key, "v2"))
+                emb_v2.append((Path(emb.filename), Path(emb.filename).relative_to(EMB_PATH).as_posix(), "v2"))
             elif emb.shape == VXL_SHAPE:
-                emb_vXL.append((Path(emb.filename), key, "vXL"))
+                emb_vXL.append((Path(emb.filename), Path(emb.filename).relative_to(EMB_PATH).as_posix(), "vXL"))
             else:
-                emb_unknown.append((Path(emb.filename), key, ""))
+                emb_unknown.append((Path(emb.filename), Path(emb.filename).relative_to(EMB_PATH).as_posix(), ""))
 
         results = sort_models(emb_v1) + sort_models(emb_v2) + sort_models(emb_vXL) + sort_models(emb_unknown)
     except AttributeError:


### PR DESCRIPTION
Adds relative paths to embeds per the model standard, so subdirectories and extensions can be searched behind the scenes.