### PR TITLE
Add TIPO configuration for tag prompt in third-party selectors

### DIFF
--- a/javascript/_textAreas.js
+++ b/javascript/_textAreas.js
@@ -86,6 +86,13 @@ const thirdParty = {
         "selectors": [
             "Found tags",
         ]
+    },
+    "TIPO": {
+        "base": "#tab_txt2img",
+        "hasIds": false,
+        "selectors": [
+            "Tag Prompt"
+        ]
     }
 }
 


### PR DESCRIPTION
This will be a small change to accommodate this extension.

https://github.com/KohakuBlueleaf/z-tipo-extension