### PR TITLE
Added support for Forge classic

### DIFF
--- a/scripts/shared_paths.py
+++ b/scripts/shared_paths.py
@@ -22,7 +22,22 @@ TAGS_PATH = Path(scripts.basedir()).joinpath("tags").absolute()
 # The path to the folder containing the wildcards and embeddings
 WILDCARD_PATH = FILE_DIR.joinpath("scripts/wildcards").absolute()
 EMB_PATH = Path(shared.cmd_opts.embeddings_dir).absolute()
-HYP_PATH = Path(shared.cmd_opts.hypernetwork_dir).absolute()
+
+# Forge Classic detection
+try:
+    from modules_forge.forge_version import version as forge_version
+    IS_FORGE_CLASSIC = forge_version == "classic"
+except ImportError:
+    IS_FORGE_CLASSIC = False
+
+# Forge Classic skips it
+if not IS_FORGE_CLASSIC:
+    try:
+        HYP_PATH = Path(shared.cmd_opts.hypernetwork_dir).absolute()
+    except AttributeError:
+        HYP_PATH = None
+else:
+    HYP_PATH = None
 
 try:
     LORA_PATH = Path(shared.cmd_opts.lora_dir).absolute()

--- a/scripts/tag_autocomplete_helper.py
+++ b/scripts/tag_autocomplete_helper.py
@@ -515,7 +515,7 @@ def write_temp_files(skip_wildcard_refresh = False):
         # Write yaml extension wildcards to umi_tags.txt and wc_yaml.json if found
         get_yaml_wildcards()
 
-    if HYP_PATH.exists():
+    if HYP_PATH is not None and HYP_PATH.exists():
         hypernets = get_hypernetworks()
         if hypernets:
             write_to_temp_file('hyp.txt', hypernets)


### PR DESCRIPTION
https://github.com/DominikDoom/a1111-sd-webui-tagcomplete/issues/320

Added support for Forge classic.
Forge Classic does not support Hypernetworks and omits --hypernetwork-dir, which causes AttributeError in the extension.
I’ve added a compatibility check to avoid accessing HYP_PATH if it's None.