### PR TITLE
Fix SDNext ModernUI by following the cursor

### DIFF
--- a/javascript/tagAutocomplete.js
+++ b/javascript/tagAutocomplete.js
@@ -364,7 +364,7 @@ function showResults(textArea) {
 
     if (TAC_CFG.slidingPopup) {
         let caretPosition = getCaretCoordinates(textArea, textArea.selectionEnd);
-        let offsetTop = textArea.offsetTop + caretPosition.top + 10; // Adjust this value for desired distance below cursor
+        let offsetTop = textArea.offsetTop + caretPosition.top - textArea.scrollTop + 10; // Adjust this value for desired distance below cursor
         let offsetLeft = Math.min(textArea.offsetLeft - textArea.scrollLeft + caretPosition.left, textArea.offsetWidth - parentDiv.offsetWidth);
 
         parentDiv.style.top = `${offsetTop}px`; // Position below the cursor

--- a/javascript/tagAutocomplete.js
+++ b/javascript/tagAutocomplete.js
@@ -31,7 +31,7 @@ const autocompleteCSS = `
         position: absolute;
         z-index: 999;
         max-width: calc(100% - 1.5rem);
-        margin: 5px 0 0 0;
+        flex-direction: column; /* Ensure children stack vertically */
     }
     .autocompleteResults {
         background-color: var(--results-bg) !important;
@@ -44,6 +44,7 @@ const autocompleteCSS = `
         overflow-y: var(--results-overflow-y);
         overflow-x: hidden;
         word-break: break-word;
+        margin-top: 10px; /* Margin to create space below the cursor */
     }
     .sideInfo {
         display: none;
@@ -362,10 +363,12 @@ function showResults(textArea) {
     parentDiv.style.display = "flex";
 
     if (TAC_CFG.slidingPopup) {
-        let caretPosition = getCaretCoordinates(textArea, textArea.selectionEnd).left;
-        let offset = Math.min(textArea.offsetLeft - textArea.scrollLeft + caretPosition, textArea.offsetWidth - parentDiv.offsetWidth);
+        let caretPosition = getCaretCoordinates(textArea, textArea.selectionEnd);
+        let offsetTop = textArea.offsetTop + caretPosition.top + 10; // Adjust this value for desired distance below cursor
+        let offsetLeft = Math.min(textArea.offsetLeft - textArea.scrollLeft + caretPosition.left, textArea.offsetWidth - parentDiv.offsetWidth);
 
-        parentDiv.style.left = `${offset}px`;
+        parentDiv.style.top = `${offsetTop}px`; // Position below the cursor
+        parentDiv.style.left = `${offsetLeft}px`;
     } else {
         if (parentDiv.style.left)
             parentDiv.style.removeProperty("left");

--- a/scripts/shared_paths.py
+++ b/scripts/shared_paths.py
@@ -21,8 +21,8 @@ TAGS_PATH = Path(scripts.basedir()).joinpath("tags").absolute()
 
 # The path to the folder containing the wildcards and embeddings
 try: # SD.Next
-    WILDCARD_PATH = Path(shared.cmd_opts.wildcards_dir).absolute()
-except AttributeError: # A1111
+    WILDCARD_PATH = Path(shared.opts.wildcards_dir).absolute()
+except Exception: # A1111
     WILDCARD_PATH = FILE_DIR.joinpath("scripts/wildcards").absolute()
 EMB_PATH = Path(shared.cmd_opts.embeddings_dir).absolute()
 

--- a/scripts/shared_paths.py
+++ b/scripts/shared_paths.py
@@ -20,7 +20,10 @@ except ImportError:
 TAGS_PATH = Path(scripts.basedir()).joinpath("tags").absolute()
 
 # The path to the folder containing the wildcards and embeddings
-WILDCARD_PATH = FILE_DIR.joinpath("scripts/wildcards").absolute()
+try: # SD.Next
+    WILDCARD_PATH = Path(shared.cmd_opts.wildcards_dir).absolute()
+except AttributeError: # A1111
+    WILDCARD_PATH = FILE_DIR.joinpath("scripts/wildcards").absolute()
 EMB_PATH = Path(shared.cmd_opts.embeddings_dir).absolute()
 
 # Forge Classic detection

--- a/scripts/tag_autocomplete_helper.py
+++ b/scripts/tag_autocomplete_helper.py
@@ -503,7 +503,14 @@ def write_style_names(*args, **kwargs):
 def write_temp_files(skip_wildcard_refresh = False):
     # Write wildcards to wc.txt if found
     if WILDCARD_PATH.exists() and not skip_wildcard_refresh:
-        wildcards = [WILDCARD_PATH.relative_to(FILE_DIR).as_posix()] + get_wildcards()
+        try:
+            # Attempt to create a relative path, but fall back to an absolute path if not possible
+            relative_wildcard_path = WILDCARD_PATH.relative_to(FILE_DIR).as_posix()
+        except ValueError:
+            # If the paths are not relative, use the absolute path
+            relative_wildcard_path = WILDCARD_PATH.as_posix()
+
+        wildcards = [relative_wildcard_path] + get_wildcards()
         if wildcards:
             write_to_temp_file('wc.txt', wildcards)
 


### PR DESCRIPTION
Tagcomplete extension puts the result box below the prompt box. This works with the old UI but this causes the results box to be on top of the prompt box on ModernUI as seen in the example. This PR fixes this issue by making the result box follow the cursor.

This PR is based on the [SDNext fix repo](https://github.com/Nyx01/SDNext_AutocompleteFix) with additional scroll check so the result box won't disappear into the abyss if we scroll down in the text box and done more cleanups on the SDNext fix repo so it won't do unnecessary code changes.

Second fix is for the wildcards dir. SDNext allows users to change the wildcards dir and sets the default to `models/wildcards` instead of `scripts/wildcards`. This PR adds a fix for this too.

Example of the prompt box covering the prompts:

![Screenshot From 2025-05-05 20-16-17](https://github.com/user-attachments/assets/dbfef4bc-dec4-4006-a3c2-b0375a663b89)

Prompt box looks like this after this PR:

![Screenshot From 2025-05-05 20-14-21](https://github.com/user-attachments/assets/589ef8bb-5324-4438-944a-5e63cfe02c6f)


Also this new behavior continues in the old UI too. Results box now follows the cursor on the old UI too:

![Screenshot From 2025-05-05 20-11-03](https://github.com/user-attachments/assets/1883cfcb-2c75-4f48-ae0e-2d896fabc619)
