### PR TITLE
Update shared_paths.py

### DIFF
--- a/scripts/shared_paths.py
+++ b/scripts/shared_paths.py
@@ -37,14 +37,14 @@ except ImportError:
 if not IS_FORGE_CLASSIC:
     try:
         HYP_PATH = Path(shared.cmd_opts.hypernetwork_dir).absolute()
-    except AttributeError:
+    except (AttributeError, TypeError):
         HYP_PATH = None
 else:
     HYP_PATH = None
 
 try:
     LORA_PATH = Path(shared.cmd_opts.lora_dir).absolute()
-except AttributeError:
+except (AttributeError, TypeError):
     LORA_PATH = None
 
 try:
@@ -52,7 +52,7 @@ try:
         LYCO_PATH = Path(shared.cmd_opts.lyco_dir_backcompat).absolute()
     except:
         LYCO_PATH = Path(shared.cmd_opts.lyco_dir).absolute() # attempt original non-backcompat path
-except AttributeError:
+except (AttributeError, TypeError):
     LYCO_PATH = None
 
 


### PR DESCRIPTION
This will fix a TypeError in Shared_Paths.py that can be passed in SDNext as it can return NoneType if the user has not specifically specified the hypernetworks folder with --hypernetwork-dir=C:\Some\Path preventing the extension from working.