### PR TITLE
Improve compatibility of dynamicprompts YAML wildcards

### DIFF
--- a/scripts/tag_autocomplete_helper.py
+++ b/scripts/tag_autocomplete_helper.py
@@ -151,7 +151,7 @@ def parse_umi_format(umi_tags, data):
         count += 1
 
 
-def parse_dynamic_prompt_format(yaml_wildcards, data, path):
+def parse_dynamic_prompt_format(yaml_wildcards, data, path, root):
     # Recurse subkeys, delete those without string lists as values
     def recurse_dict(d: dict):
         for key, value in d.copy().items():
@@ -162,6 +162,9 @@ def parse_dynamic_prompt_format(yaml_wildcards, data, path):
 
     try:
         recurse_dict(data)
+        # prepend folder parts
+        for part in reversed(path.relative_to(root).parent.parts):
+            data = {part: data}
         # Add to yaml_wildcards
         yaml_wildcards[path.name] = data
     except:
@@ -172,14 +175,14 @@ def get_yaml_wildcards():
     """Returns a list of all tags found in extension YAML files found under a Tags: key."""
     yaml_files = []
     for path in WILDCARD_EXT_PATHS:
-        yaml_files.extend(p for p in path.rglob("*.yml") if p.is_file())
-        yaml_files.extend(p for p in path.rglob("*.yaml") if p.is_file())
+        yaml_files.extend((p, path) for p in path.rglob("*.yml") if p.is_file())
+        yaml_files.extend((p, path) for p in path.rglob("*.yaml") if p.is_file())
 
     yaml_wildcards = {}
 
     umi_tags = {} # { tag: count }
 
-    for path in yaml_files:
+    for path, root in yaml_files:
         try:
             with open(path, encoding="utf8") as file:
                 data = yaml.safe_load(file)
@@ -187,7 +190,7 @@ def get_yaml_wildcards():
                     if (is_umi_format(data)):
                         parse_umi_format(umi_tags, data)
                     else:
-                        parse_dynamic_prompt_format(yaml_wildcards, data, path)
+                        parse_dynamic_prompt_format(yaml_wildcards, data, path, root)
                 else:
                     print('No data found in ' + path.name)
         except (yaml.YAMLError, UnicodeDecodeError, AttributeError, TypeError) as e:

--- a/scripts/tag_autocomplete_helper.py
+++ b/scripts/tag_autocomplete_helper.py
@@ -157,7 +157,8 @@ def parse_dynamic_prompt_format(yaml_wildcards, data, path, root):
         for key, value in d.copy().items():
             if isinstance(value, dict):
                 recurse_dict(value)
-            elif not (isinstance(value, list) and all(isinstance(v, str) for v in value)):
+            elif (not isinstance(value, str) and  # a string value is treated as a list of one item
+                    not (isinstance(value, list) and all(isinstance(v, str) for v in value))):
                 del d[key]
 
     try:


### PR DESCRIPTION
The current implementation for handling YAML wildcards is inconsistent with dynamicprompts in two ways:

1. Folder paths are prepended to tree structures in YAML.
2. Single strings are parsed as collections containing a single item.

### Folder paths are prepended to tree structures in YAML.

The relevant code can be found at https://github.com/adieyal/dynamicprompts/blob/58815af851848fdfd0ed89e18c483dd37eb2a9b1/src/dynamicprompts/wildcards/tree/build.py#L40.

Only the folder component (`file_path.parent`) is prepended.

### Single strings are parsed as collections containing a single item.

See the implementation at https://github.com/adieyal/dynamicprompts/blob/58815af851848fdfd0ed89e18c483dd37eb2a9b1/src/dynamicprompts/wildcards/collection/structured.py#L71.

This behavior is not clearly documented in dynamicprompts; I have submitted a PR to update the documentation: https://github.com/adieyal/dynamicprompts/pull/144

### Example

```yaml
# a/b/c.yaml
key: value
```

With the YAML file above, the placeholder `__a/b/key__` expands to `value`.
