### PR TITLE
Add sibling-import fallback for Forge Neo / namespace-package edge cases

### DIFF
--- a/scripts/model_keyword_support.py
+++ b/scripts/model_keyword_support.py
@@ -1,10 +1,14 @@
 # This file provides support for the model-keyword extension to add known lora keywords on completion
-
 import csv
 import hashlib
+import sys
 from pathlib import Path
 
-from scripts.shared_paths import EXT_PATH, STATIC_TEMP_PATH, TEMP_PATH
+try:
+    from scripts.shared_paths import EXT_PATH, STATIC_TEMP_PATH, TEMP_PATH
+except ModuleNotFoundError:
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    from shared_paths import EXT_PATH, STATIC_TEMP_PATH, TEMP_PATH
 
 # Set up our hash cache
 known_hashes_file = TEMP_PATH.joinpath("known_lora_hashes.txt")

--- a/scripts/tag_autocomplete_helper.py
+++ b/scripts/tag_autocomplete_helper.py
@@ -17,10 +17,17 @@ from fastapi.responses import FileResponse, JSONResponse, Response
 from modules import hashes, script_callbacks, sd_models, shared
 from pydantic import BaseModel
 
-from scripts.model_keyword_support import (get_lora_simple_hash,
-                                           load_hash_cache, update_hash_cache,
-                                           write_model_keyword_path)
-from scripts.shared_paths import *
+try:
+    from scripts.model_keyword_support import (get_lora_simple_hash,
+                                               load_hash_cache, update_hash_cache,
+                                               write_model_keyword_path)
+    from scripts.shared_paths import *
+except ModuleNotFoundError:
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    from model_keyword_support import (get_lora_simple_hash,
+                                       load_hash_cache, update_hash_cache,
+                                       write_model_keyword_path)
+    from shared_paths import *
 
 try:
     from modules import sd_hijack

--- a/scripts/tag_frequency_db.py
+++ b/scripts/tag_frequency_db.py
@@ -1,7 +1,13 @@
 import sqlite3
+import sys
 from contextlib import contextmanager
+from pathlib import Path
 
-from scripts.shared_paths import TAGS_PATH
+try:
+    from scripts.shared_paths import TAGS_PATH
+except ModuleNotFoundError:
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    from shared_paths import TAGS_PATH
 
 db_file = TAGS_PATH.joinpath("tag_frequency.db")
 timeout = 30


### PR DESCRIPTION
## Problem

On some Forge Neo and Forge Classic installs, the extension silently fails to load with:

*** Error loading script: model_keyword_support.py
ModuleNotFoundError: No module named 'scripts.shared_paths'
*** Error loading script: tag_autocomplete_helper.py
ModuleNotFoundError: No module named 'scripts.model_keyword_support'
*** Error loading script: tag_frequency_db.py
ModuleNotFoundError: No module named 'scripts.shared_paths'



Result: the extension's `on_ui_settings` callback never registers, so no `tac_*` keys reach the JS `opts` object, so `JSON.parse(opts["tac_keymap"])` throws on `undefined`, and the tag popup never wires up. From the user's point of view: "the extension does nothing."

## Cause

Python's namespace-package resolution for `scripts` doesn't always pick up the extension's `scripts/` folder when the webui has its own `scripts/` folder — the webui's folder is found first, doesn't contain `shared_paths`, and `ModuleNotFoundError` is raised instead of also checking the extension's folder.

## Fix

Mirrors the existing fallback pattern already used in `tag_autocomplete_helper.py` for `tag_frequency_db`: try the package-style import first, and if it fails, add the script's own directory to `sys.path` and re-import bare. No behavior change on webuis where the package import works.

Applied to:
- `scripts/model_keyword_support.py`
- `scripts/tag_frequency_db.py`
- `scripts/tag_autocomplete_helper.py`

Tested on Forge Neo and Forge Classic.